### PR TITLE
enable dynamic atributes to subclasses

### DIFF
--- a/lib/atlas/entity/base_entity.rb
+++ b/lib/atlas/entity/base_entity.rb
@@ -74,7 +74,7 @@ module Atlas
       end
 
       def to_hash
-        keys = defined?(@@dynamic_attributes) ? @parameters.keys : internal_parameters
+        keys = dynamic_attributes? ? @parameters.keys : internal_parameters
         values = @parameters.values_at(*keys)
         keys.zip(values).to_h
       end
@@ -88,8 +88,8 @@ module Atlas
 
       protected
 
-      def self.dynamic_attributes
-        @@dynamic_attributes = true
+      def dynamic_attributes?
+        false
       end
 
       private

--- a/lib/atlas/entity/dynamic_attributes.rb
+++ b/lib/atlas/entity/dynamic_attributes.rb
@@ -1,0 +1,10 @@
+module Atlas
+  module Entity
+    class DynamicAttributes
+      def dynamic_attributes?
+        true
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Ex:

```
class Entity < Atlas::Entity::BaseEntity
  include Atlas::Entity::DynamicAttributes
end
```

Should habilit `@parameters.keys` instead of `internal_parameters`