### PR TITLE
feat(base controller) supporting multiple serializers namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Atlas
 
 ## CHANGELOG
+- Changed Suporte a múltiplos namespaces de serializers
 
 ## 0.10.4
 - Changed Tamanho do stacktrace nos alertas do Slack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Atlas
 
 ## CHANGELOG
+
+## 0.12.0
 - Changed Suporte a múltiplos namespaces de serializers
+
+## 0.11.0
+- ?
 
 ## 0.10.4
 - Changed Tamanho do stacktrace nos alertas do Slack

--- a/lib/atlas/api/base_controller.rb
+++ b/lib/atlas/api/base_controller.rb
@@ -6,7 +6,7 @@ module Atlas
       extend Dry::Configurable
       include Atlas::Util::I18nScope
       include Atlas::Service::Util::ResponseHelpers
-      setting :serializers_namespace
+      setting :serializers_namespaces
 
       def self.included(base)
         base.class_eval do

--- a/lib/atlas/api/renderer/json_renderer.rb
+++ b/lib/atlas/api/renderer/json_renderer.rb
@@ -20,8 +20,13 @@ module Atlas
           return API::Serializer::DummySerializer if data.blank? || data.is_a?(Hash)
           return serializer_class_to(data.first) if data.is_a?(Array)
           entity = data.class.name.split('::').last
-          BaseController.config.serializers_namespace.const_get("#{entity}Serializer".to_sym)
-        rescue NameError
+
+          BaseController.config.serializers_namespaces.each do |namespace|
+            return namespace.const_get("#{entity}Serializer".to_sym)
+          rescue NameError
+            next
+          end
+
           API::Serializer::DummySerializer
         end
       end

--- a/lib/atlas/version.rb
+++ b/lib/atlas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Atlas
-  VERSION = '0.11.0'
+  VERSION = '0.12.0'
 end


### PR DESCRIPTION
Deu certo:
```
[5] pry(main)> Atlas::API::Renderer::JsonRenderer.new(nil).serializer_class_to(Devices::Entity::Device.new)
=> Devices::API::Serializer::DeviceSerializer

[6] pry(main)> Atlas::API::Renderer::JsonRenderer.new(nil).serializer_class_to(App::Entity::Sale.new)
=> App::API::Serializer::SaleSerializer
```